### PR TITLE
Update RandomHearth.lua

### DIFF
--- a/src/RandomHearth.lua
+++ b/src/RandomHearth.lua
@@ -43,6 +43,7 @@ local rhToys = {
 	210455, --Draenic Hologem
 	228940, --Notorious Thread's Hearthstone
 	235016, --Redeployment Module
+	236687, -- Explosive Hearthstone
 }
 
 ------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/RandomHearth.toc
+++ b/src/RandomHearth.toc
@@ -5,6 +5,17 @@
 ## Notes: Uses a random hearthstone toy
 ## SavedVariables: rhDB
 ## IconTexture: Interface\Icons\Inv_misc_rune_01
+## Category-enUS: Inventory
+## Category-deDE: Inventar
+## Category-esES: Inventario
+## Category-esMX: Inventario
+## Category-frFR: Inventaire
+## Category-itIT: Inventario
+## Category-koKR: 소지품
+## Category-ptBR: Inventário
+## Category-ruRU: Предметы
+## Category-zhCN: 物品栏
+## Category-zhTW: 物品欄
 
 Localisation.lua
 RandomHearth.lua


### PR DESCRIPTION
https://www.wowhead.com/item=236687/explosive-hearthstone


Since Patch 11.1, it is possible to categorize an addon and group them. More info: https://warcraft.wiki.gg/wiki/Patch_11.1.0/API_changes
